### PR TITLE
Cuda Architecure Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
   set(ProbGPU_Compiler_Flags_CUDA "")
 endif()
 # KS: Remove quotes from the variable
-string(REPLACE "\"" "" NuOscillator_Compiler_Flags_CUDA ${NuOscillator_Compiler_Flags_CUDA})
+string(REPLACE "\"" "" ProbGPU_Compiler_Flags_CUDA ${ProbGPU_Compiler_Flags_CUDA})
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endif()
 if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
   set(ProbGPU_Compiler_Flags_CUDA "")
 endif()
-# KS: Remove quotes from the variable
-string(REPLACE "\"" "" ProbGPU_Compiler_Flags_CUDA ${ProbGPU_Compiler_Flags_CUDA})
+
+separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
   set(ProbGPU_Compiler_Flags_CUDA "")
 endif()
+# KS: Remove quotes from the variable
+string(REPLACE "\"" "" NuOscillator_Compiler_Flags_CUDA ${NuOscillator_Compiler_Flags_CUDA})
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
       #KS: See this for more info https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
   if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.23 )
-      set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75 80 86 )
+      set(CMAKE_CUDA_ARCHITECTURES all )
           #KS: Consider using native, requires cmake 3.24... will be terrible for containers but should results in more optimised code
       #set(CMAKE_CUDA_ARCHITECTURES native )
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
 endif()
 
 separate_arguments(ProbGPU_Compiler_Flags_CUDA)
+message(STATUS "Set CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,16 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   endif()
 endif()
 
-if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
-  set(ProbGPU_Compiler_Flags_CUDA "")
-endif()
+#if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
+#  set(ProbGPU_Compiler_Flags_CUDA "")
+#endif()
 
-separate_arguments(ProbGPU_Compiler_Flags_CUDA)
-message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
-message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
-string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+#separate_arguments(ProbGPU_Compiler_Flags_CUDA)
+#message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
+#message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
+#string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 
-add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
+#add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
 add_library(ProbGPU SHARED probGpu.cu)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
 endif()
 
 separate_arguments(ProbGPU_Compiler_Flags_CUDA)
-message(STATUS "Set CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
+message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
+string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 
 add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
 add_library(ProbGPU SHARED probGpu.cu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ elseif(NOT DEFINED CMAKE_INSTALL_PREFIX)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/${CMAKE_SYSTEM_NAME}")
 endif()
 
-add_library(ProbGPU SHARED probGpu.cu)
-
-
 #KS: Allow user to define CMAKE_CUDA_ARCHITECTURES
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   #KS: See this for more info https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
@@ -36,11 +33,14 @@ separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
 
-add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
+
+add_library(ProbGPU SHARED probGpu.cu)
 
 target_include_directories(
-  ProbGPU PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                       $<INSTALL_INTERFACE:include>
+  ProbGPU PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
 )
 
 set_target_properties(ProbGPU PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
 
-add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:{ProbGPU_Compiler_Flags_CUDA}>")
 
 add_library(ProbGPU SHARED probGpu.cu)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,10 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   endif()
 endif()
 
-if(NOT DEFINED PrbGPU_Compiler_Flags_CUDA)
-  set(PrbGPU_Compiler_Flags_CUDA "")
+if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
+  set(ProbGPU_Compiler_Flags_CUDA "")
 endif()
-add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${PrbGPU_Compiler_Flags_CUDA}>)
+add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(
   ProbGPU PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,27 +14,25 @@ endif()
 
 #KS: Allow user to define CMAKE_CUDA_ARCHITECTURES
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  #KS: See this for more info https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
+      #KS: See this for more info https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
   if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.23 )
-      set(CMAKE_CUDA_ARCHITECTURES all )
+      set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75 80 86 )
           #KS: Consider using native, requires cmake 3.24... will be terrible for containers but should results in more optimised code
       #set(CMAKE_CUDA_ARCHITECTURES native )
   else()
   #KS: Apparently with newer cmake and GPU
-      set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75)
+      set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75 80 86)
   endif()
+#KS: Bit hacky but to properly pass cuda flags we need
+string(REPLACE ";" " " CMAKE_CUDA_ARCHITECTURES_STRING "${CMAKE_CUDA_ARCHITECTURES}")
+else()
+#KS this may look hacky however CPM isn't build for passing stuff like this. If CMAKE_CUDA_ARCHITECTURES is passed CPM it will be string not list. Thus we convert it to list
+set(CMAKE_CUDA_ARCHITECTURES_STRING ${CMAKE_CUDA_ARCHITECTURES})
+string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 endif()
 
-#if(NOT DEFINED ProbGPU_Compiler_Flags_CUDA)
-#  set(ProbGPU_Compiler_Flags_CUDA "")
-#endif()
+message(STATUS "Set CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES_STRING}")
 
-#separate_arguments(ProbGPU_Compiler_Flags_CUDA)
-#message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
-#message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
-#string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
-
-#add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
 add_library(ProbGPU SHARED probGpu.cu)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,37 @@ endif()
 
 add_library(ProbGPU SHARED probGpu.cu)
 
-set_target_properties(ProbGPU PROPERTIES 
-			      CUDA_SEPARABLE_COMPILATION ON 
-			      LINKER_LANGUAGE CUDA
-			      EXPORT_NAME ProbGPU)
 
-set_property(TARGET ProbGPU PROPERTY CUDA_ARCHITECTURES 60 61 70 75)
+#KS: Allow user to define CMAKE_CUDA_ARCHITECTURES
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  #KS: See this for more info https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
+  if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.23 )
+      set(CMAKE_CUDA_ARCHITECTURES all )
+          #KS: Consider using native, requires cmake 3.24... will be terrible for containers but should results in more optimised code
+      #set(CMAKE_CUDA_ARCHITECTURES native )
+  else()
+  #KS: Apparently with newer cmake and GPU
+      set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75)
+  endif()
+endif()
+
+if(NOT DEFINED NuOscillator_Compiler_Flags_CUDA)
+  set(NuOscillator_Compiler_Flags_CUDA "")
+endif()
+add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${NuOscillator_Compiler_Flags_CUDA}>)
 
 target_include_directories(
   ProbGPU PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                        $<INSTALL_INTERFACE:include>
 )
+
+
+set_target_properties(ProbGPU PROPERTIES
+			      CUDA_SEPARABLE_COMPILATION ON
+			      LINKER_LANGUAGE CUDA
+			      EXPORT_NAME ProbGPU)
+
+set_property(TARGET ProbGPU PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
 
 install(TARGETS ProbGPU 
                 EXPORT ProbGPU-target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,7 @@ separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
 message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
 
-add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:{ProbGPU_Compiler_Flags_CUDA}>")
-
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>")
 add_library(ProbGPU SHARED probGpu.cu)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,16 +28,15 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   endif()
 endif()
 
-if(NOT DEFINED NuOscillator_Compiler_Flags_CUDA)
-  set(NuOscillator_Compiler_Flags_CUDA "")
+if(NOT DEFINED PrbGPU_Compiler_Flags_CUDA)
+  set(PrbGPU_Compiler_Flags_CUDA "")
 endif()
-add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${NuOscillator_Compiler_Flags_CUDA}>)
+add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${PrbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(
   ProbGPU PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                        $<INSTALL_INTERFACE:include>
 )
-
 
 set_target_properties(ProbGPU PROPERTIES
 			      CUDA_SEPARABLE_COMPILATION ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 separate_arguments(ProbGPU_Compiler_Flags_CUDA)
 message(STATUS "Set ProbGPU CUDA compiler options: ${ProbGPU_Compiler_Flags_CUDA}")
+message(STATUS "Set ProbGPU CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES}")
+
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${ProbGPU_Compiler_Flags_CUDA}>)
 
 target_include_directories(


### PR DESCRIPTION
Here I take MaCh3 CUDA achitecture:
![image](https://github.com/dbarrow257/ProbGPU/assets/45295406/6489b0dd-e7b1-4fe4-be42-e6c320e7250f)
here you can see they are proely set both in NuOscialltor and PropGPU
<img width="521" alt="CUDA_Architecture" src="https://github.com/dbarrow257/ProbGPU/assets/45295406/85188c40-c51c-4e01-91a2-b88a97f60a7f">

Here is proof that compilation flagse defiene in MaCh3 whihc looks like
```
        "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-O3;-Werror;cross-execution-space-call;-w>"
        "$<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-allow-expensive-optimizations=true;-Xptxas=-fmad=true;-Xptxas=-O3;>"
        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpic;-Xcompiler=-O3;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
```
are both set correctly for ProbGPU
<img width="1268" alt="flagsProbGPU" src="https://github.com/dbarrow257/ProbGPU/assets/45295406/e390fae3-2122-4c38-9093-1432eb35f85b">

but also CudaProb3
![CudaProb3](https://github.com/dbarrow257/ProbGPU/assets/45295406/9d197300-0954-49b0-adec-706ea13ea85e)
